### PR TITLE
Read ALLOWED_HOSTS from environment

### DIFF
--- a/app/techblog_cms/settings.py
+++ b/app/techblog_cms/settings.py
@@ -7,7 +7,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Security settings
 SECRET_KEY = os.environ.get('SECRET_KEY')
 DEBUG = os.environ.get('DEBUG', 'False') == 'True'
-ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split
+ALLOWED_HOSTS = [
+    host.strip()
+    for host in os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
+]
 
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
## Summary
- parse `ALLOWED_HOSTS` from the `ALLOWED_HOSTS` environment variable and strip whitespace from each host

## Testing
- `pytest` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d061543c832eb1b6f3f8112eb5c1