### PR TITLE
Harden compose secrets and service users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ SECRET_KEY=your-secret-key-here
 ALLOWED_HOSTS=.localhost,127.0.0.1
 DATABASE_URL=postgres://user:password@localhost:5432/dbname
 REDIS_URL=redis://localhost:6379/1
+POSTGRES_USER=your-db-user
+POSTGRES_PASSWORD=your-db-password
+POSTGRES_DB=your-db-name
+REDIS_PASSWORD=your-redis-password
 
 # OAuth Settings
 GOOGLE_CLIENT_ID=your-google-client-id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       - NGINX_ENVSUBST_TEMPLATE_DIR=/etc/nginx/conf.d
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/conf.d
       - NGINX_HOST=localhost
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
     healthcheck:
       test: ["CMD", "nginx", "-t"]
       interval: 30s
@@ -47,20 +52,27 @@ services:
     expose:
       - 8000
     environment:
-      SECRET_KEY: ${SECRET_KEY:-somesecretkey}  # Replace with a strong secret key
+      SECRET_KEY: ${SECRET_KEY}  # Require a strong secret key via env
       DEBUG: ${DEBUG:-False}
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1,blog.iohub.link}
-      DATABASE_URL: postgres://${POSTGRES_USER:-techblog}:${POSTGRES_PASSWORD:-techblogpass}@db:5432/${POSTGRES_DB:-techblogdb}
-      REDIS_URL: redis://redis:6379/0
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
       DJANGO_SETTINGS_MODULE: techblog_cms.settings
       PYTHONPATH: /app
       TESTING: 'True'
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
     depends_on:
       - db
       - redis
     networks:
       - techblog_network
     restart: always
+    user: appuser
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
     # Security: Runs the application as a non-root user.
     # Environment variables for sensitive settings.
 
@@ -69,27 +81,37 @@ services:
     image: postgres:16-alpine
     volumes:
       - db_data:/var/lib/postgresql/data # Persist data
-    ports:
-      - "5432:5432"
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-techblog}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-techblogpass}
-      POSTGRES_DB: ${POSTGRES_DB:-techblogdb}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     networks:
       - techblog_network
     restart: always
+    user: postgres
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
     # Security: Uses a specific PostgreSQL version.
     # Environment variables for credentials.
 
   # Caching - Redis
   redis:
     image: redis:7-alpine
-    command: redis-server --requirepass your_redis_password # Set a password
-    ports:
-      - "6379:6379"
+    command: redis-server --requirepass $REDIS_PASSWORD
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
     networks:
       - techblog_network
     restart: always
+    user: redis
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 256M
     # Security: Requires a password for authentication.
     # Consider network restrictions for enhanced security.
 
@@ -103,6 +125,12 @@ services:
     networks:
       - techblog_network
     restart: unless-stopped
+    user: nginx
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
 
   certbot:
     image: certbot/certbot:latest


### PR DESCRIPTION
## Summary
- require external secrets for Django, Postgres, and Redis
- drop database and cache port mappings and inject Redis password via env
- add non-root users and resource limits to services

## Testing
- `docker compose config` *(fails: command not found)*
- `SECRET_KEY=test POSTGRES_USER=user POSTGRES_PASSWORD=pass POSTGRES_DB=db REDIS_PASSWORD=pass pytest -q` *(fails: could not translate host name "db" to address: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f5ee8744832e85ae810e5395acf8