### PR TITLE
Configure Nginx to use explicit config files

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -5,7 +5,8 @@ FROM nginx:1.25-alpine
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy configuration and static files
-COPY nginx.conf /etc/nginx/conf.d/
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY static /var/www/static
 
 # Set proper permissions for static files

--- a/Dockerfile.nginx.static
+++ b/Dockerfile.nginx.static
@@ -1,26 +1,3 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 # Use an official Nginx image as a parent image
 FROM nginx:1.21-alpine
 
@@ -28,7 +5,8 @@ FROM nginx:1.21-alpine
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy custom Nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 
 # Copy static files
 COPY static /var/www/static

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,24 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
## Summary
- add global nginx.conf that loads conf.d snippets
- ensure Dockerfile.nginx and Dockerfile.nginx.static copy config files to correct locations

## Testing
- `pytest` *(fails: could not translate host name "db" to address)*
- `docker build -f Dockerfile.nginx -t techblog_nginx_test .` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install docker.io -y` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa5322ec832e81c5a5813228296c