### PR TITLE
Remove duplicate Django requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ psycopg2-binary>=2.9,<3.0
 gunicorn>=21.2,<22.0
 Django==4.2.10
 python-decouple>=3.8,<4.0
-django>=4.2,<5.0
 Pillow>=10.0,<11.0
 playwright>=1.40,<2.0
 pytest>=7.0,<8.0


### PR DESCRIPTION
## Summary
- keep a single pinned Django dependency in root requirements

## Testing
- `pip install -r requirements.txt`
- `pip check`
- `pytest` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68b829ee4d58832e8d7fd57ad7438439