### PR TITLE
Add Redis password via env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,11 @@ DEBUG=False
 SECRET_KEY=your-secret-key-here
 ALLOWED_HOSTS=.localhost,127.0.0.1
 DATABASE_URL=postgres://user:password@localhost:5432/dbname
-REDIS_URL=redis://localhost:6379/1
+REDIS_PASSWORD=your-redis-password
+REDIS_URL=redis://:your-redis-password@localhost:6379/1
 POSTGRES_USER=your-db-user
 POSTGRES_PASSWORD=your-db-password
 POSTGRES_DB=your-db-name
-REDIS_PASSWORD=your-redis-password
 
 # OAuth Settings
 GOOGLE_CLIENT_ID=your-google-client-id

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -14,6 +14,8 @@ services:
     environment:
       DEBUG: 'True'
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1,staging.example.com}
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       
   db:
     ports:
@@ -22,3 +24,6 @@ services:
   redis:
     ports:
       - "6380:6379"  # 本番環境と異なるポートを使用
+    command: redis-server --requirepass $REDIS_PASSWORD
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}


### PR DESCRIPTION
## Summary
- add `REDIS_PASSWORD` to env example and document redis URL with password
- parameterize redis service in staging compose file to require password
- pass redis URL and password into Django service so all containers share one secret

## Testing
- `pytest` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68b82d375850832eb2cd6132753afe75